### PR TITLE
fix: 自由サイズの配列スキンでクリーンアップ時に正しいオブジェクトも消していた問題を修正

### DIFF
--- a/Packages/uGUI-Skinner/Editor/SkinPartsOnArrayInspector.cs
+++ b/Packages/uGUI-Skinner/Editor/SkinPartsOnArrayInspector.cs
@@ -22,7 +22,7 @@ namespace Pspkurara.UI.Skinner
 
 		public void CleanupFields(EditorSkinPartsPropertry property)
 		{
-			SkinnerEditorUtility.CleanArray<T>(property.objectReferenceValues, DefaultArrayLength);
+			SkinnerEditorUtility.CleanObjectReferenceArrayWithFlexibleSize<T>(property.objectReferenceValues, DefaultArrayLength);
 			CleanupFieldsOtherThanObjectReference(property);
 		}
 

--- a/Packages/uGUI-Skinner/Editor/SkinnerEditorUtility.cs
+++ b/Packages/uGUI-Skinner/Editor/SkinnerEditorUtility.cs
@@ -171,6 +171,39 @@ namespace Pspkurara.UI.Skinner
 			}
 		}
 
+		public static void CleanObjectReferenceArrayWithFlexibleSize<T>(SerializedProperty prop, int minArraySize = 1, T defaultValue = null) where T : Object
+		{
+			HashSet<Object> cleanupCheckedObjects = new HashSet<Object>();
+			int currentArraySize = prop.arraySize;
+			for (int i = currentArraySize - 1; i >= 0; i--)
+			{
+				var arrayObj = prop.GetArrayElementAtIndex(i);
+				bool removeArray = false;
+				if (cleanupCheckedObjects.Contains(arrayObj.objectReferenceValue))
+				{
+					removeArray = true;
+				}
+				if (arrayObj.objectReferenceValue == null || !arrayObj.objectReferenceValue is T)
+				{
+					removeArray = i >= minArraySize;
+				}
+				cleanupCheckedObjects.Add(arrayObj.objectReferenceValue);
+				if (removeArray)
+				{
+					arrayObj.objectReferenceValue = null;
+					prop.DeleteArrayElementAtIndex(i);
+					continue;
+				}
+			}
+			int listCount = prop.arraySize;
+			for (int i = listCount; i < minArraySize; i++)
+			{
+				prop.InsertArrayElementAtIndex(prop.arraySize);
+				var arrayObj = prop.GetArrayElementAtIndex(i);
+				FieldClean(arrayObj, defaultValue);
+			}
+		}
+
 		public static void CleanObject<T>(SerializedProperty prop, int index, T defaultValue = null) where T : Object
 		{
 			if (prop.GetArrayElementAtIndex(index).objectReferenceValue is T) return;


### PR DESCRIPTION
https://github.com/pspkurara/ugui-skinner/issues/1
対策